### PR TITLE
Add monorepo cleanup script

### DIFF
--- a/clean.mjs
+++ b/clean.mjs
@@ -1,0 +1,17 @@
+import {rimrafSync} from "rimraf";
+import path from "node:path";
+
+console.log("Starting cleanup script.");
+
+const baseDir = path.dirname(new URL(import.meta.url).pathname);
+
+rimrafSync(path.join(baseDir, ".turbo"));
+rimrafSync(path.join(baseDir, "apps/**/.turbo"), {glob: true});
+rimrafSync(path.join(baseDir, "apps/**/dist"), {glob: true});
+rimrafSync(path.join(baseDir, "apps/**/node_modules"), {glob: true});
+rimrafSync(path.join(baseDir, "apps/**/.vite"), {glob: true});
+rimrafSync(path.join(baseDir, "packages/**/.turbo"), {glob: true});
+rimrafSync(path.join(baseDir, "packages/**/dist"), {glob: true});
+rimrafSync(path.join(baseDir, "packages/**/node_modules"), {glob: true});
+
+console.log("Cleanup script completed.");

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/jelovac"
   },
   "scripts": {
+    "clean": "node clean.mjs",
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
@@ -23,6 +24,7 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
+    "rimraf": "^6.0.1",
     "turbo": "^2.2.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8802,6 +8802,7 @@ __metadata:
     husky: "npm:^9.1.6"
     lint-staged: "npm:^15.2.10"
     prettier: "npm:^3.3.3"
+    rimraf: "npm:^6.0.1"
     turbo: "npm:^2.2.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

Added a global cleanup script which will automate cleaning up build artifacts, node_modules and turborepo cache across all projects within monorepo.

This was needed due to cache not being invalidated in some cases. So I made a simple script to ease my pain while troubleshooting build issues in development.