### PR TITLE
Migrate from tsc to bundler

### DIFF
--- a/apps/phunt-cli/rollup.config.mjs
+++ b/apps/phunt-cli/rollup.config.mjs
@@ -60,7 +60,10 @@ const rollupOptions = {
     }),
     typescript({
       tsconfig: "tsconfig.build.json",
-      moduleResolution: "bundler",
+      compilerOptions: {
+        moduleResolution: "NodeNext",
+        module: "NodeNext",
+      },
     }),
   ],
   external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77

--- a/apps/phunt-cli/tsconfig.base.json
+++ b/apps/phunt-cli/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@112dev/phunt-typescript-config/node.tsconfig.json",
+  "extends": "@112dev/phunt-typescript-config/standard.tsconfig.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/phunt-contracts/package.json
+++ b/packages/phunt-contracts/package.json
@@ -2,31 +2,9 @@
   "name": "@112dev/phunt-contracts",
   "version": "1.0.0-beta.2",
   "license": "Apache-2.0",
-  "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    },
-    "./db": {
-      "types": "./src/db.ts",
-      "default": "./dist/db.js"
-    },
-    "./file-search": {
-      "types": "./src/file-search.ts",
-      "default": "./dist/file-search.js"
-    },
-    "./file": {
-      "types": "./src/file.ts",
-      "default": "./dist/file.js"
-    },
-    "./logger": {
-      "types": "./src/logger.ts",
-      "default": "./dist/logger.js"
-    }
-  },
+  "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/phunt-contracts/package.json
+++ b/packages/phunt-contracts/package.json
@@ -3,6 +3,23 @@
   "version": "1.0.0-beta.2",
   "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts"
+    },
+    "./db": {
+      "types": "./dist/db.d.ts"
+    },
+    "./file-search": {
+      "types": "./dist/file-search.d.ts"
+    },
+    "./file": {
+      "types": "./dist/file.d.ts"
+    },
+    "./logger": {
+      "types": "./dist/logger.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/phunt-contracts/tsconfig.base.json
+++ b/packages/phunt-contracts/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@112dev/phunt-typescript-config/node.tsconfig.json",
+  "extends": "@112dev/phunt-typescript-config/standard.tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/phunt-contracts/tsconfig.build.json
+++ b/packages/phunt-contracts/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-core/package.json
+++ b/packages/phunt-core/package.json
@@ -2,18 +2,17 @@
   "name": "@112dev/phunt-core",
   "version": "1.0.0-beta.1",
   "license": "Apache-2.0",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.mjs"
   },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rollup --config rollup.config.mjs",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write --ignore-unknown .",
     "test": "jest"
@@ -28,11 +27,16 @@
     "@112dev/phunt-contracts": "workspace:*",
     "@112dev/phunt-eslint-config": "workspace:*",
     "@112dev/phunt-prettier-config": "workspace:*",
+    "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
     "@jest/globals": "^29.7.0",
+    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-typescript": "^12.1.1",
     "eslint": "^9.13.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
+    "rollup": "^4.24.3",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.3"
   },

--- a/packages/phunt-core/package.json
+++ b/packages/phunt-core/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.mjs"
   },
@@ -30,13 +31,13 @@
     "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
     "@jest/globals": "^29.7.0",
-    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-commonjs": "^25.0.8",
     "@rollup/plugin-node-resolve": "^15.3.0",
-    "@rollup/plugin-typescript": "^12.1.1",
+    "@rollup/plugin-typescript": "^11.1.6",
     "eslint": "^9.13.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
-    "rollup": "^4.24.3",
+    "rollup": "^4.24.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.3"
   },

--- a/packages/phunt-core/rollup.config.mjs
+++ b/packages/phunt-core/rollup.config.mjs
@@ -1,9 +1,9 @@
 import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs";
 import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import { readFileSync } from "node:fs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
@@ -36,10 +36,18 @@ const rollupOptions = {
   },
   plugins: [
     cleanOnBuildStart("dist"),
-    resolve(),
-    commonjs(),
+    nodeResolve({
+      preferBuiltins: false,
+    }),
+    commonjs({
+      ignoreTryCatch: false,
+    }),
     typescript({
       tsconfig: "tsconfig.build.json",
+      compilerOptions: {
+        moduleResolution: "NodeNext",
+        module: "NodeNext",
+      },
     }),
   ],
   external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77

--- a/packages/phunt-core/rollup.config.mjs
+++ b/packages/phunt-core/rollup.config.mjs
@@ -1,0 +1,48 @@
+import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs";
+import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import typescript from "@rollup/plugin-typescript";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+
+/**
+ * @type {import("rollup").RollupOptions}
+ */
+const rollupOptions = {
+  input: "src/index.ts",
+  output: [
+    {
+      dir: "dist",
+      format: "es",
+      preserveModules: true,
+      entryFileNames: "[name].mjs",
+      sourcemap: true,
+    },
+    {
+      dir: "dist",
+      format: "cjs",
+      preserveModules: true,
+      entryFileNames: "[name].cjs",
+      sourcemap: true,
+    },
+  ],
+  strictDeprecations: true,
+  treeshake: {
+    moduleSideEffects: false,
+    propertyReadSideEffects: false,
+    tryCatchDeoptimization: false,
+  },
+  plugins: [
+    cleanOnBuildStart("dist"),
+    resolve(),
+    commonjs(),
+    typescript({
+      tsconfig: "tsconfig.build.json",
+    }),
+  ],
+  external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77
+};
+
+export default assembleRollupConfig(rollupOptions);

--- a/packages/phunt-core/tsconfig.base.json
+++ b/packages/phunt-core/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@112dev/phunt-typescript-config/node.tsconfig.json",
+  "extends": "@112dev/phunt-typescript-config/standard.tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/phunt-core/tsconfig.build.json
+++ b/packages/phunt-core/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "declaration": true,
-    "moduleResolution": "bundler"
+    "declaration": true
   },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-core/tsconfig.build.json
+++ b/packages/phunt-core/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": true,
+    "moduleResolution": "bundler"
+  },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-db/package.json
+++ b/packages/phunt-db/package.json
@@ -2,19 +2,17 @@
   "name": "@112dev/phunt-db",
   "version": "1.0.0-beta.2",
   "license": "Apache-2.0",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.mjs"
   },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "clean": "rimraf dist",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rollup --config rollup.config.mjs",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write --ignore-unknown ."
   },
@@ -28,10 +26,13 @@
     "@112dev/phunt-contracts": "workspace:*",
     "@112dev/phunt-eslint-config": "workspace:*",
     "@112dev/phunt-prettier-config": "workspace:*",
+    "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
+    "@rollup/plugin-typescript": "^12.1.1",
     "@types/better-sqlite3": "^7.6.11",
     "eslint": "^9.13.0",
     "prettier": "^3.3.3",
+    "rollup": "^4.24.3",
     "typescript": "^5.6.2"
   },
   "dependencies": {

--- a/packages/phunt-db/package.json
+++ b/packages/phunt-db/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.mjs"
   },
@@ -28,11 +29,13 @@
     "@112dev/phunt-prettier-config": "workspace:*",
     "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
-    "@rollup/plugin-typescript": "^12.1.1",
+    "@rollup/plugin-commonjs": "^25.0.8",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/better-sqlite3": "^7.6.11",
     "eslint": "^9.13.0",
     "prettier": "^3.3.3",
-    "rollup": "^4.24.3",
+    "rollup": "^4.24.0",
     "typescript": "^5.6.2"
   },
   "dependencies": {

--- a/packages/phunt-db/rollup.config.mjs
+++ b/packages/phunt-db/rollup.config.mjs
@@ -2,6 +2,8 @@ import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs"
 import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
 import typescript from "@rollup/plugin-typescript";
 import { readFileSync } from "node:fs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
@@ -34,8 +36,18 @@ const rollupOptions = {
   },
   plugins: [
     cleanOnBuildStart("dist"),
+    nodeResolve({
+      preferBuiltins: false,
+    }),
+    commonjs({
+      ignoreTryCatch: false,
+    }),
     typescript({
       tsconfig: "tsconfig.build.json",
+      compilerOptions: {
+        moduleResolution: "NodeNext",
+        module: "NodeNext",
+      },
     }),
   ],
   external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77

--- a/packages/phunt-db/rollup.config.mjs
+++ b/packages/phunt-db/rollup.config.mjs
@@ -1,0 +1,44 @@
+import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs";
+import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
+import typescript from "@rollup/plugin-typescript";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+
+/**
+ * @type {import("rollup").RollupOptions}
+ */
+const rollupOptions = {
+  input: "src/index.ts",
+  output: [
+    {
+      dir: "dist",
+      format: "es",
+      preserveModules: true,
+      entryFileNames: "[name].mjs",
+      sourcemap: true,
+    },
+    {
+      dir: "dist",
+      format: "cjs",
+      preserveModules: true,
+      entryFileNames: "[name].cjs",
+      sourcemap: true,
+    },
+  ],
+  strictDeprecations: true,
+  treeshake: {
+    moduleSideEffects: false,
+    propertyReadSideEffects: false,
+    tryCatchDeoptimization: false,
+  },
+  plugins: [
+    cleanOnBuildStart("dist"),
+    typescript({
+      tsconfig: "tsconfig.build.json",
+    }),
+  ],
+  external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77
+};
+
+export default assembleRollupConfig(rollupOptions);

--- a/packages/phunt-db/tsconfig.base.json
+++ b/packages/phunt-db/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@112dev/phunt-typescript-config/node.tsconfig.json",
+  "extends": "@112dev/phunt-typescript-config/standard.tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/phunt-db/tsconfig.build.json
+++ b/packages/phunt-db/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "declaration": true,
-    "moduleResolution": "bundler"
+    "declaration": true
   },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-db/tsconfig.build.json
+++ b/packages/phunt-db/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": true,
+    "moduleResolution": "bundler"
+  },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-typeguards/package.json
+++ b/packages/phunt-typeguards/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.mjs"
   },
@@ -27,10 +28,12 @@
     "@112dev/phunt-prettier-config": "workspace:*",
     "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
-    "@rollup/plugin-typescript": "^12.1.1",
+    "@rollup/plugin-commonjs": "^25.0.8",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-typescript": "^11.1.6",
     "eslint": "^9.11.1",
     "prettier": "^3.3.3",
-    "rollup": "^4.24.3",
+    "rollup": "^4.24.0",
     "typescript": "^5.6.2"
   }
 }

--- a/packages/phunt-typeguards/package.json
+++ b/packages/phunt-typeguards/package.json
@@ -2,18 +2,17 @@
   "name": "@112dev/phunt-typeguards",
   "version": "1.0.0-beta.2",
   "license": "Apache-2.0",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.mjs"
   },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rollup --config rollup.config.mjs",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write --ignore-unknown ."
   },
@@ -26,9 +25,12 @@
   "devDependencies": {
     "@112dev/phunt-eslint-config": "workspace:*",
     "@112dev/phunt-prettier-config": "workspace:*",
+    "@112dev/phunt-rollup-config": "workspace:*",
     "@112dev/phunt-typescript-config": "workspace:*",
+    "@rollup/plugin-typescript": "^12.1.1",
     "eslint": "^9.11.1",
     "prettier": "^3.3.3",
+    "rollup": "^4.24.3",
     "typescript": "^5.6.2"
   }
 }

--- a/packages/phunt-typeguards/rollup.config.mjs
+++ b/packages/phunt-typeguards/rollup.config.mjs
@@ -2,6 +2,8 @@ import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs"
 import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
 import typescript from "@rollup/plugin-typescript";
 import { readFileSync } from "node:fs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
@@ -34,9 +36,18 @@ const rollupOptions = {
   },
   plugins: [
     cleanOnBuildStart("dist"),
+    nodeResolve({
+      preferBuiltins: false,
+    }),
+    commonjs({
+      ignoreTryCatch: false,
+    }),
     typescript({
       tsconfig: "tsconfig.build.json",
-      moduleResolution: "bundler",
+      compilerOptions: {
+        moduleResolution: "NodeNext",
+        module: "NodeNext",
+      },
     }),
   ],
   external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77

--- a/packages/phunt-typeguards/rollup.config.mjs
+++ b/packages/phunt-typeguards/rollup.config.mjs
@@ -1,0 +1,45 @@
+import { assembleRollupConfig } from "@112dev/phunt-rollup-config/functions.mjs";
+import { cleanOnBuildStart } from "@112dev/phunt-rollup-config/plugins/clean-on-build-start.mjs";
+import typescript from "@rollup/plugin-typescript";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+
+/**
+ * @type {import("rollup").RollupOptions}
+ */
+const rollupOptions = {
+  input: "src/index.ts",
+  output: [
+    {
+      dir: "dist",
+      format: "es",
+      preserveModules: true,
+      entryFileNames: "[name].mjs",
+      sourcemap: true,
+    },
+    {
+      dir: "dist",
+      format: "cjs",
+      preserveModules: true,
+      entryFileNames: "[name].cjs",
+      sourcemap: true,
+    },
+  ],
+  strictDeprecations: true,
+  treeshake: {
+    moduleSideEffects: false,
+    propertyReadSideEffects: false,
+    tryCatchDeoptimization: false,
+  },
+  plugins: [
+    cleanOnBuildStart("dist"),
+    typescript({
+      tsconfig: "tsconfig.build.json",
+      moduleResolution: "bundler",
+    }),
+  ],
+  external: Object.keys(pkg.dependencies || {}), // https://github.com/rollup/rollup-plugin-node-resolve/issues/77
+};
+
+export default assembleRollupConfig(rollupOptions);

--- a/packages/phunt-typeguards/tsconfig.base.json
+++ b/packages/phunt-typeguards/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@112dev/phunt-typescript-config/node.tsconfig.json",
+  "extends": "@112dev/phunt-typescript-config/standard.tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/phunt-typeguards/tsconfig.build.json
+++ b/packages/phunt-typeguards/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": true
+  },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/phunt-typeguards/tsconfig.json
+++ b/packages/phunt-typeguards/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.base.json"
+  "extends": "./tsconfig.base.json"
 }

--- a/packages/phunt-typescript-config/package.json
+++ b/packages/phunt-typescript-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.2",
   "license": "Apache-2.0",
   "files": [
-    "node.tsconfig.json"
+    "standard.tsconfig.json"
   ],
   "peerDependencies": {
     "typescript": "^5.6.3"

--- a/packages/phunt-typescript-config/standard.tsconfig.json
+++ b/packages/phunt-typescript-config/standard.tsconfig.json
@@ -1,16 +1,17 @@
 {
   "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "target": "ES2022",
     "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
-    "noUncheckedIndexedAccess": true,
-    "lib": ["ES2022"]
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,14 +59,19 @@ __metadata:
     "@112dev/phunt-db": "workspace:*"
     "@112dev/phunt-eslint-config": "workspace:*"
     "@112dev/phunt-prettier-config": "workspace:*"
+    "@112dev/phunt-rollup-config": "workspace:*"
     "@112dev/phunt-typeguards": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
     "@jest/globals": "npm:^29.7.0"
+    "@rollup/plugin-commonjs": "npm:^28.0.1"
+    "@rollup/plugin-node-resolve": "npm:^15.3.0"
+    "@rollup/plugin-typescript": "npm:^12.1.1"
     date-fns: "npm:^3.6.0"
     eslint: "npm:^9.13.0"
     exifreader: "npm:^4.23.5"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"
+    rollup: "npm:^4.24.3"
     ts-jest: "npm:^29.2.5"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.6.3"
@@ -81,11 +86,14 @@ __metadata:
     "@112dev/phunt-contracts": "workspace:*"
     "@112dev/phunt-eslint-config": "workspace:*"
     "@112dev/phunt-prettier-config": "workspace:*"
+    "@112dev/phunt-rollup-config": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
+    "@rollup/plugin-typescript": "npm:^12.1.1"
     "@types/better-sqlite3": "npm:^7.6.11"
     better-sqlite3: "npm:^11.2.1"
     eslint: "npm:^9.13.0"
     prettier: "npm:^3.3.3"
+    rollup: "npm:^4.24.3"
     typescript: "npm:^5.6.2"
   languageName: unknown
   linkType: soft
@@ -178,9 +186,12 @@ __metadata:
   dependencies:
     "@112dev/phunt-eslint-config": "workspace:*"
     "@112dev/phunt-prettier-config": "workspace:*"
+    "@112dev/phunt-rollup-config": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
+    "@rollup/plugin-typescript": "npm:^12.1.1"
     eslint: "npm:^9.11.1"
     prettier: "npm:^3.3.3"
+    rollup: "npm:^4.24.3"
     typescript: "npm:^5.6.2"
   languageName: unknown
   linkType: soft
@@ -2104,6 +2115,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^28.0.1":
+  version: 28.0.1
+  resolution: "@rollup/plugin-commonjs@npm:28.0.1"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.0.1"
+    commondir: "npm:^1.0.1"
+    estree-walker: "npm:^2.0.2"
+    fdir: "npm:^6.2.0"
+    is-reference: "npm:1.2.1"
+    magic-string: "npm:^0.30.3"
+    picomatch: "npm:^4.0.2"
+  peerDependencies:
+    rollup: ^2.68.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10c0/15d73306f539763a4b0d5723a0be9099b56d07118ff12b4c7f4c04b26e762076706e9f88a45f131d639ed9b7bd52e51facf93f2ca265b994172677b48ca705fe
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-json@npm:^6.1.0":
   version: 6.1.0
   resolution: "@rollup/plugin-json@npm:6.1.0"
@@ -2170,6 +2201,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-typescript@npm:^12.1.1":
+  version: 12.1.1
+  resolution: "@rollup/plugin-typescript@npm:12.1.1"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.1.0"
+    resolve: "npm:^1.22.1"
+  peerDependencies:
+    rollup: ^2.14.0||^3.0.0||^4.0.0
+    tslib: "*"
+    typescript: ">=3.7.0"
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+    tslib:
+      optional: true
+  checksum: 10c0/1418ed9dc784c09ae82c7a171f453c42e26c48b5c557147cfee0fc95857711a3a0250efc7937b65923a5171bfd35c8d33dff82fe561ed2578c6d575ac7a826ae
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0":
   version: 5.1.3
   resolution: "@rollup/pluginutils@npm:5.1.3"
@@ -2193,9 +2243,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.24.4"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm64@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-android-arm64@npm:4.24.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-android-arm64@npm:4.24.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2207,6 +2271,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-arm64@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.24.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-darwin-x64@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-darwin-x64@npm:4.24.0"
@@ -2214,9 +2285,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-x64@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-darwin-x64@npm:4.24.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.24.4"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.24.4"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.0"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.4"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
@@ -2228,9 +2327,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm-musleabihf@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.24.4"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm64-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.24.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.24.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2242,9 +2355,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm64-musl@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.24.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.4"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2256,9 +2383,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-riscv64-gnu@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.24.4"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-s390x-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.24.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.24.4"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2270,9 +2411,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-x64-gnu@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.24.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-x64-musl@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-x64-musl@npm:4.24.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.24.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -2284,6 +2439,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-arm64-msvc@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.24.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-ia32-msvc@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.24.0"
@@ -2291,9 +2453,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-ia32-msvc@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.24.4"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-x64-msvc@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.24.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.24.4":
+  version: 4.24.4
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.24.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5383,6 +5559,18 @@ __metadata:
   dependencies:
     pend: "npm:~1.2.0"
   checksum: 10c0/304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.2.0":
+  version: 6.4.2
+  resolution: "fdir@npm:6.4.2"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/34829886f34a3ca4170eca7c7180ec4de51a3abb4d380344063c0ae2e289b11d2ba8b724afee974598c83027fea363ff598caf2b51bc4e6b1e0d8b80cc530573
   languageName: node
   linkType: hard
 
@@ -9603,6 +9791,75 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/77fb549c1de8afd1142d2da765adbb0cdab9f13c47df5217f00b5cf40b74219caa48c6ba2157f6249313ee81b6fa4c4fa8b3d2a0347ad6220739e00e580a808d
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.24.3":
+  version: 4.24.4
+  resolution: "rollup@npm:4.24.4"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.24.4"
+    "@rollup/rollup-android-arm64": "npm:4.24.4"
+    "@rollup/rollup-darwin-arm64": "npm:4.24.4"
+    "@rollup/rollup-darwin-x64": "npm:4.24.4"
+    "@rollup/rollup-freebsd-arm64": "npm:4.24.4"
+    "@rollup/rollup-freebsd-x64": "npm:4.24.4"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.24.4"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.24.4"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.24.4"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.24.4"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.24.4"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.24.4"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.24.4"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.24.4"
+    "@rollup/rollup-linux-x64-musl": "npm:4.24.4"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.24.4"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.24.4"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.24.4"
+    "@types/estree": "npm:1.0.6"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-powerpc64le-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/8e9e9ce4dc8cc48acf258a26519ed1bbbbdac99fd701e89d11c31271e01b4663fe61d839f7906a49c0983b1a49e2acc622948d7665ff0f57ecc48d872835d1ce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,15 +63,15 @@ __metadata:
     "@112dev/phunt-typeguards": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
     "@jest/globals": "npm:^29.7.0"
-    "@rollup/plugin-commonjs": "npm:^28.0.1"
+    "@rollup/plugin-commonjs": "npm:^25.0.8"
     "@rollup/plugin-node-resolve": "npm:^15.3.0"
-    "@rollup/plugin-typescript": "npm:^12.1.1"
+    "@rollup/plugin-typescript": "npm:^11.1.6"
     date-fns: "npm:^3.6.0"
     eslint: "npm:^9.13.0"
     exifreader: "npm:^4.23.5"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"
-    rollup: "npm:^4.24.3"
+    rollup: "npm:^4.24.0"
     ts-jest: "npm:^29.2.5"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.6.3"
@@ -88,12 +88,14 @@ __metadata:
     "@112dev/phunt-prettier-config": "workspace:*"
     "@112dev/phunt-rollup-config": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
-    "@rollup/plugin-typescript": "npm:^12.1.1"
+    "@rollup/plugin-commonjs": "npm:^25.0.8"
+    "@rollup/plugin-node-resolve": "npm:^15.3.0"
+    "@rollup/plugin-typescript": "npm:^11.1.6"
     "@types/better-sqlite3": "npm:^7.6.11"
     better-sqlite3: "npm:^11.2.1"
     eslint: "npm:^9.13.0"
     prettier: "npm:^3.3.3"
-    rollup: "npm:^4.24.3"
+    rollup: "npm:^4.24.0"
     typescript: "npm:^5.6.2"
   languageName: unknown
   linkType: soft
@@ -188,10 +190,12 @@ __metadata:
     "@112dev/phunt-prettier-config": "workspace:*"
     "@112dev/phunt-rollup-config": "workspace:*"
     "@112dev/phunt-typescript-config": "workspace:*"
-    "@rollup/plugin-typescript": "npm:^12.1.1"
+    "@rollup/plugin-commonjs": "npm:^25.0.8"
+    "@rollup/plugin-node-resolve": "npm:^15.3.0"
+    "@rollup/plugin-typescript": "npm:^11.1.6"
     eslint: "npm:^9.11.1"
     prettier: "npm:^3.3.3"
-    rollup: "npm:^4.24.3"
+    rollup: "npm:^4.24.0"
     typescript: "npm:^5.6.2"
   languageName: unknown
   linkType: soft
@@ -2115,26 +2119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-commonjs@npm:^28.0.1":
-  version: 28.0.1
-  resolution: "@rollup/plugin-commonjs@npm:28.0.1"
-  dependencies:
-    "@rollup/pluginutils": "npm:^5.0.1"
-    commondir: "npm:^1.0.1"
-    estree-walker: "npm:^2.0.2"
-    fdir: "npm:^6.2.0"
-    is-reference: "npm:1.2.1"
-    magic-string: "npm:^0.30.3"
-    picomatch: "npm:^4.0.2"
-  peerDependencies:
-    rollup: ^2.68.0||^3.0.0||^4.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: 10c0/15d73306f539763a4b0d5723a0be9099b56d07118ff12b4c7f4c04b26e762076706e9f88a45f131d639ed9b7bd52e51facf93f2ca265b994172677b48ca705fe
-  languageName: node
-  linkType: hard
-
 "@rollup/plugin-json@npm:^6.1.0":
   version: 6.1.0
   resolution: "@rollup/plugin-json@npm:6.1.0"
@@ -2201,25 +2185,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-typescript@npm:^12.1.1":
-  version: 12.1.1
-  resolution: "@rollup/plugin-typescript@npm:12.1.1"
-  dependencies:
-    "@rollup/pluginutils": "npm:^5.1.0"
-    resolve: "npm:^1.22.1"
-  peerDependencies:
-    rollup: ^2.14.0||^3.0.0||^4.0.0
-    tslib: "*"
-    typescript: ">=3.7.0"
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-    tslib:
-      optional: true
-  checksum: 10c0/1418ed9dc784c09ae82c7a171f453c42e26c48b5c557147cfee0fc95857711a3a0250efc7937b65923a5171bfd35c8d33dff82fe561ed2578c6d575ac7a826ae
-  languageName: node
-  linkType: hard
-
 "@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0":
   version: 5.1.3
   resolution: "@rollup/pluginutils@npm:5.1.3"
@@ -2243,23 +2208,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.24.4"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-android-arm64@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-android-arm64@npm:4.24.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-android-arm64@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-android-arm64@npm:4.24.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2271,13 +2222,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.24.4"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-darwin-x64@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-darwin-x64@npm:4.24.0"
@@ -2285,37 +2229,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-darwin-x64@npm:4.24.4"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-freebsd-arm64@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.24.4"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-freebsd-x64@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.24.4"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.0"
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.24.4"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
@@ -2327,23 +2243,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.24.4"
-  conditions: os=linux & cpu=arm & libc=musl
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-arm64-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.24.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm64-gnu@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.24.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2355,23 +2257,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.24.4"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.0"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.24.4"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2383,23 +2271,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.24.4"
-  conditions: os=linux & cpu=riscv64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-s390x-gnu@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.24.0"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-s390x-gnu@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.24.4"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2411,23 +2285,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.24.4"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-x64-musl@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-linux-x64-musl@npm:4.24.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-x64-musl@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.24.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -2439,13 +2299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.24.4"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-win32-ia32-msvc@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.24.0"
@@ -2453,23 +2306,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.24.4"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-win32-x64-msvc@npm:4.24.0":
   version: 4.24.0
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.24.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-x64-msvc@npm:4.24.4":
-  version: 4.24.4
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.24.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5559,18 +5398,6 @@ __metadata:
   dependencies:
     pend: "npm:~1.2.0"
   checksum: 10c0/304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
-  languageName: node
-  linkType: hard
-
-"fdir@npm:^6.2.0":
-  version: 6.4.2
-  resolution: "fdir@npm:6.4.2"
-  peerDependencies:
-    picomatch: ^3 || ^4
-  peerDependenciesMeta:
-    picomatch:
-      optional: true
-  checksum: 10c0/34829886f34a3ca4170eca7c7180ec4de51a3abb4d380344063c0ae2e289b11d2ba8b724afee974598c83027fea363ff598caf2b51bc4e6b1e0d8b80cc530573
   languageName: node
   linkType: hard
 
@@ -9791,75 +9618,6 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/77fb549c1de8afd1142d2da765adbb0cdab9f13c47df5217f00b5cf40b74219caa48c6ba2157f6249313ee81b6fa4c4fa8b3d2a0347ad6220739e00e580a808d
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^4.24.3":
-  version: 4.24.4
-  resolution: "rollup@npm:4.24.4"
-  dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.24.4"
-    "@rollup/rollup-android-arm64": "npm:4.24.4"
-    "@rollup/rollup-darwin-arm64": "npm:4.24.4"
-    "@rollup/rollup-darwin-x64": "npm:4.24.4"
-    "@rollup/rollup-freebsd-arm64": "npm:4.24.4"
-    "@rollup/rollup-freebsd-x64": "npm:4.24.4"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.24.4"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.24.4"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.24.4"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.24.4"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.24.4"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.24.4"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.24.4"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.24.4"
-    "@rollup/rollup-linux-x64-musl": "npm:4.24.4"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.24.4"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.24.4"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.24.4"
-    "@types/estree": "npm:1.0.6"
-    fsevents: "npm:~2.3.2"
-  dependenciesMeta:
-    "@rollup/rollup-android-arm-eabi":
-      optional: true
-    "@rollup/rollup-android-arm64":
-      optional: true
-    "@rollup/rollup-darwin-arm64":
-      optional: true
-    "@rollup/rollup-darwin-x64":
-      optional: true
-    "@rollup/rollup-freebsd-arm64":
-      optional: true
-    "@rollup/rollup-freebsd-x64":
-      optional: true
-    "@rollup/rollup-linux-arm-gnueabihf":
-      optional: true
-    "@rollup/rollup-linux-arm-musleabihf":
-      optional: true
-    "@rollup/rollup-linux-arm64-gnu":
-      optional: true
-    "@rollup/rollup-linux-arm64-musl":
-      optional: true
-    "@rollup/rollup-linux-powerpc64le-gnu":
-      optional: true
-    "@rollup/rollup-linux-riscv64-gnu":
-      optional: true
-    "@rollup/rollup-linux-s390x-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-musl":
-      optional: true
-    "@rollup/rollup-win32-arm64-msvc":
-      optional: true
-    "@rollup/rollup-win32-ia32-msvc":
-      optional: true
-    "@rollup/rollup-win32-x64-msvc":
-      optional: true
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 10c0/8e9e9ce4dc8cc48acf258a26519ed1bbbbdac99fd701e89d11c31271e01b4663fe61d839f7906a49c0983b1a49e2acc622948d7665ff0f57ecc48d872835d1ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This is an attempt to fix phunt-desktop Vite bundler build, as it is not able to resolve phunt-typeguards types during a new feature development which used them:

```
src/store/app-config.ts (4:9): "objectContainsCodeProperty" is not exported by "../../packages/phunt-typeguards/dist/index.js", imported by "src/store/app-config.ts".
file: /home/XXXXXXXXX/phunt/apps/phunt-desktop/src/store/app-config.ts:4:9

2: import { z } from "zod";
3: import { Logger } from "@112dev/phunt-contracts";
4: import { objectContainsCodeProperty } from "@112dev/phunt-typeguards";
```

Not entirely sure what is causing the issue. However, I believe it has something to do with:
1. mixing cjs and mjs
2. syntax used to define location where type definitions are exported during build

As a result I have done the following changes:
1. Introduced rollup which will generate both cjs and mjs bundles
2. Changed the way how type definition location was declared in package.json (imports.types vs types root keyword)



